### PR TITLE
feat: accept incoming messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,37 @@ conversation threads.
   returns `deliveredTo: 0`. A client subscribing later and polling with the
   default `since` will receive the backlog.
 
+### `POST /incoming`
+Delivers a message from an external service to a client using a shared secret.
+
+**Request body**
+
+```json
+{
+  "client_id": "CLIENT_ID",
+  "secret": "CLIENT_SECRET",
+  "content": "Message text"
+}
+```
+
+**Response**
+
+```json
+{ "id": "MESSAGE_ID" }
+```
+
+**Example**
+
+```bash
+curl -X POST http://localhost:3000/incoming \
+  -H "Content-Type: application/json" \
+  -d '{"client_id":"CLIENT_ID","secret":"CLIENT_SECRET","content":"hi"}'
+```
+
+**Notes**
+
+- Returns `403` if the provided secret does not match the registered client.
+
 ### `POST /subscribe`
 Subscribes the authenticated client to a channel.
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, expect, test } from "bun:test";
+
+process.env.DB_PATH = ":memory:";
+process.env.PORT = "0";
+const { server } = await import("./index");
+const base = `http://localhost:${server.port}`;
+
+// register two clients for tests
+const c1Res = await fetch(`${base}/register`, { method: "POST" });
+const c1 = await c1Res.json();
+const c2Res = await fetch(`${base}/register`, { method: "POST" });
+const c2 = await c2Res.json();
+
+afterAll(() => server.stop());
+
+test("register provides credentials", () => {
+  expect(c1.id).toBeDefined();
+  expect(c1.secret).toBeDefined();
+  expect(c1.token).toBeDefined();
+});
+
+test("publish delivers to recipient", async () => {
+  const res = await fetch(`${base}/publish`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      Authorization: `Bearer ${c1.token}`,
+    },
+    body: JSON.stringify({ channel: c2.id, content: "hello" }),
+  });
+  expect(res.status).toBe(200);
+  const pub = await res.json();
+  expect(pub.deliveredTo).toBe(1);
+  const pollRes = await fetch(`${base}/poll`, {
+    headers: { Authorization: `Bearer ${c2.token}` },
+  });
+  const messages = await pollRes.json();
+  expect(messages.some((m: any) => m.content === "hello")).toBe(true);
+});
+
+test("incoming accepts valid secret", async () => {
+  const res = await fetch(`${base}/incoming`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_id: c2.id,
+      secret: c2.secret,
+      content: "external",
+    }),
+  });
+  expect(res.status).toBe(200);
+  const { id } = await res.json();
+  expect(id).toBeDefined();
+  const pollRes = await fetch(`${base}/poll`, {
+    headers: { Authorization: `Bearer ${c2.token}` },
+  });
+  const messages = await pollRes.json();
+  expect(messages.some((m: any) => m.content === "external")).toBe(true);
+});
+
+test("incoming rejects invalid secret", async () => {
+  const res = await fetch(`${base}/incoming`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_id: c2.id,
+      secret: "wrong",
+      content: "bad",
+    }),
+  });
+  expect(res.status).toBe(403);
+});
+
+test("subscribe receives channel messages", async () => {
+  const sub = await fetch(`${base}/subscribe`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      Authorization: `Bearer ${c2.token}`,
+    },
+    body: JSON.stringify({ channel: "news/general" }),
+  });
+  expect(sub.status).toBe(200);
+  const pub = await fetch(`${base}/publish`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      Authorization: `Bearer ${c1.token}`,
+    },
+    body: JSON.stringify({ channel: "news/general", content: "update" }),
+  });
+  expect(pub.status).toBe(200);
+  const pollRes = await fetch(`${base}/poll`, {
+    headers: { Authorization: `Bearer ${c2.token}` },
+  });
+  const messages = await pollRes.json();
+  expect(messages.some((m: any) => m.content === "update")).toBe(true);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
         "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
-        "@types/bun": "latest"
+        "@types/bun": "latest",
+        "@types/jsonwebtoken": "^9.0.10"
       },
       "peerDependencies": {
         "typescript": "^5.0.0"
@@ -23,6 +24,24 @@
       "dependencies": {
         "bun-types": "1.2.19"
       }
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.1.0",
@@ -193,6 +212,22 @@
       "requires": {
         "bun-types": "1.2.19"
       }
+    },
+    "@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true
     },
     "@types/node": {
       "version": "24.1.0",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "obsidian-plus-server",
   "module": "index.ts",
   "type": "module",
+  "scripts": {
+    "test": "bun test"
+  },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "@types/jsonwebtoken": "^9.0.10"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"


### PR DESCRIPTION
## Summary
- add `/incoming` route for external message delivery
- validate client secret and store incoming content in `messages`
- document `/incoming` endpoint in README
- export server and allow DB/port configuration to enable testing
- add Bun test suite covering registration, publishing, incoming messages, subscriptions, and polling

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689964a4fb648332acbcd54f4adde3a3